### PR TITLE
Fix S3 prefix in backfill scripts

### DIFF
--- a/nicsan-crm-backend/backfill-s3-policies-safe.js
+++ b/nicsan-crm-backend/backfill-s3-policies-safe.js
@@ -9,6 +9,7 @@
 
 const { query } = require('./config/database');
 const { generatePolicyS3Key, uploadJSONToS3 } = require('./config/aws');
+const { withPrefix } = require('./utils/s3Prefix');
 
 // Configuration
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -71,8 +72,8 @@ async function backfillMissingPolicies() {
         try {
           console.log(`📄 Processing policy ${policy.id} (${policy.policy_number})...`);
           
-          // Generate S3 key
-          const s3Key = generatePolicyS3Key(policy.id, policy.source || 'MANUAL_FORM');
+          // Generate S3 key with proper prefix
+          const s3Key = withPrefix(generatePolicyS3Key(policy.id, policy.source || 'MANUAL_FORM'));
           
           // Prepare policy data for S3 (exclude database-specific fields)
           const policyData = { ...policy };

--- a/nicsan-crm-backend/backfill-s3-policies.js
+++ b/nicsan-crm-backend/backfill-s3-policies.js
@@ -9,6 +9,7 @@
 
 const { query } = require('./config/database');
 const { generatePolicyS3Key, uploadJSONToS3 } = require('./config/aws');
+const { withPrefix } = require('./utils/s3Prefix');
 
 async function backfillMissingPolicies() {
   console.log('🔄 Starting S3 Policy Backfill Process...\n');
@@ -39,8 +40,8 @@ async function backfillMissingPolicies() {
       try {
         console.log(`📄 Processing policy ${policy.id} (${policy.policy_number})...`);
         
-        // Generate S3 key
-        const s3Key = generatePolicyS3Key(policy.id, policy.source || 'MANUAL_FORM');
+        // Generate S3 key with proper prefix
+        const s3Key = withPrefix(generatePolicyS3Key(policy.id, policy.source || 'MANUAL_FORM'));
         
         // Prepare policy data for S3 (exclude database-specific fields)
         const policyData = { ...policy };


### PR DESCRIPTION
- Add withPrefix function to ensure policies are stored in correct S3 path
- Policies will now be stored in production/data/policies/ instead of data/policies/